### PR TITLE
feat: add advanced configuration for llms-full.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Have a look at [our own cleaning function](https://pawamoy.github.io/mkdocs-llms
 
 You can fine-tune the output of the `llms-full.txt` file by setting the following configuration options:
 
-- `prefix_url_per_page` - If set to `true`, the URL of each page will be prefixed to the content of the page in the `llms-full.txt` file. Can be useful to provide context to the LLM. 
-- `use_section_separator` - Can be set to the string that should be used to separate sections in the `llms-full.txt` file. Is wrapped with `\n` on both sides (if not empty).
-- `use_section_pages_separator` - Can be set to the string that should be used to separate pages in a section in the `llms-full.txt` file. Is wrapped with `\n` on both sides (if not empty).
-- `prefix_url_base_url` - Can be set to the URL that has to be used as a base URL for llms-full.txt URL building. If not set, the `site_url` will be used.
-- `include_section_content_in_full_output` - Can be set to `false` to not include the section content in the `llms-full.txt` file. This can be useful if you want to keep the file size small and only include the page content. Defaults to `true`.
+- `prefix_url_per_page` - (Optional)  If set to `true`, the URL of each page will be prefixed to the content of the page in the `llms-full.txt` file. Can be useful to provide context to the LLM. 
+- `use_section_separator` - (Optional) Can be set to the string that should be used to separate sections in the `llms-full.txt` file. Is wrapped with `\n` on both sides (if not empty).
+- `use_section_pages_separator` - (Optional)  Can be set to the string that should be used to separate pages in a section in the `llms-full.txt` file. Is wrapped with `\n` on both sides (if not empty).
+- `prefix_url_base_url` - (Optional)  Can be set to the URL that has to be used as a base URL for llms-full.txt URL building. If not set, the `site_url` will be used.
+- `include_section_content_in_full_output` - (Optional) Can be set to `false` to not include the section content in the `llms-full.txt` file. This can be useful if you want to keep the file size small and only include the page content. Defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -119,3 +119,13 @@ def preprocess(soup: BeautifulSoup, output: str) -> None:
 The `output` argument lets you modify the soup *depending on which file is being generated*.
 
 Have a look at [our own cleaning function](https://pawamoy.github.io/mkdocs-llmstxt/reference/mkdocs_llmstxt/#mkdocs_llmstxt.autoclean) to get inspiration.
+
+## Fine-tuning
+
+You can fine-tune the output of the `llms-full.txt` file by setting the following configuration options:
+
+- `prefix_url_per_page` - If set to `true`, the URL of each page will be prefixed to the content of the page in the `llms-full.txt` file. Can be useful to provide context to the LLM. 
+- `use_section_separator` - Can be set to the string that should be used to separate sections in the `llms-full.txt` file. Is wrapped with `\n` on both sides (if not empty).
+- `use_section_pages_separator` - Can be set to the string that should be used to separate pages in a section in the `llms-full.txt` file. Is wrapped with `\n` on both sides (if not empty).
+- `prefix_url_base_url` - Can be set to the URL that has to be used as a base URL for llms-full.txt URL building. If not set, the `site_url` will be used.
+- `include_section_content_in_full_output` - Can be set to `false` to not include the section content in the `llms-full.txt` file. This can be useful if you want to keep the file size small and only include the page content. Defaults to `true`.

--- a/src/mkdocs_llmstxt/_internal/config.py
+++ b/src/mkdocs_llmstxt/_internal/config.py
@@ -14,3 +14,8 @@ class _PluginConfig(BaseConfig):
     markdown_description = mkconf.Optional(mkconf.Type(str))
     full_output = mkconf.Optional(mkconf.Type(str))
     sections = mkconf.DictOfItems(mkconf.ListOfItems(mkconf.Type(str)))
+    prefix_url_per_page = mkconf.Type(bool, default=False)
+    use_section_separator = mkconf.Optional(mkconf.Type(str))
+    use_section_pages_separator = mkconf.Optional(mkconf.Type(str))
+    prefix_url_base_url = mkconf.Optional(mkconf.Type(str))
+    include_section_content_in_full_output = mkconf.Type(bool, default=True)


### PR DESCRIPTION
This pull request introduces new features to control the content of llms-full.txt, aiming to improve chunking efficiency and context-awareness.

You can now fine-tune the output of the llms-full.txt file by setting the following configuration options:


- **`prefix_url_per_page`**:
  - **Type**: Boolean
  - **Description**: If set to `true`, the URL of each page will be prefixed to the content of the page in the `llms-full.txt` file. This can be useful for providing context to the LLM.

- **`use_section_separator`**:
  - **Type**: String
  - **Description**: Can be set to the string that should be used to separate sections in the `llms-full.txt` file. The separator will be wrapped with `\n` on both sides (if not empty).

- **`use_section_pages_separator`**:
  - **Type**: String
  - **Description**: Can be set to the string that should be used to separate pages within a section in the `llms-full.txt` file. The separator will be wrapped with `\n` on both sides (if not empty).

- **`prefix_url_base_url`**:
  - **Type**: String
  - **Description**: Can be set to the URL that should be used as the base URL for building URLs in `llms-full.txt`. If not set, the `site_url` will be used by default.

- **`include_section_content_in_full_output`**:
  - **Type**: Boolean
  - **Description**: If set to `true`, the content of each section will be included in the full output of `llms-full.txt`. This can help in maintaining a comprehensive context.
