### PR TITLE
feat: add convert_source_blocks option for collapsible source code

### DIFF
--- a/src/mkdocs_llmstxt/_internal/config.py
+++ b/src/mkdocs_llmstxt/_internal/config.py
@@ -13,6 +13,7 @@ class _PluginConfig(BaseConfig):
     preprocess = mkconf.Optional(mkconf.File(exists=True))
     markdown_description = mkconf.Optional(mkconf.Type(str))
     full_output = mkconf.Optional(mkconf.Type(str))
+    convert_source_blocks = mkconf.Type(bool, default=False)
     sections = mkconf.DictOfItems(
         # Each list item can either be:
         #


### PR DESCRIPTION
## Summary

Adds a new configuration option `convert_source_blocks` to transform mkdocstrings source code tables into collapsible details sections with clean code blocks.

This resolves the issue where mkdocstrings `show_source=true` generates suboptimal table representations in LLM-optimized output (issue #14).

## Changes

- **New config option**: `convert_source_blocks` (boolean, default: `false`)
- **Source transformation**: Converts HTML tables with `highlighttable` class to collapsible `<details>` sections
- **Clean code blocks**: Wraps source code in proper markdown code fences with language detection
- **Backward compatible**: Opt-in feature that doesn't change existing behavior
- **Test coverage**: Added unit test for transformation functionality

## Usage

```yaml
plugins:
  - llmstxt:
      convert_source_blocks: true
      sections:
        Documentation:
          - balatrobot-api.md
```

## Before vs After

**Before** (table format in llms-full.txt):
```
| 18 19 20 21 ... | ```class BalatroClient: """Client for communicating... |
```

**After** (collapsible details):
```html
<details>
<summary>Source code</summary>

```python
class BalatroClient:
    """Client for communicating with the BalatroBot game API."""
    
    host = "127.0.0.1"
    port = 12346
    # ... rest of source code
```

</details>
```

## Implementation Details

- Detects mkdocstrings source code by `highlighttable` CSS class
- Preserves language information from existing classes
- Applied before existing autoclean/preprocess steps
- Uses simple HTML details/summary structure for better LLM processing

This provides clean, readable source code in LLM-optimized output while maintaining collapsible functionality for regular documentation.

Closes #14